### PR TITLE
Use AltCurrencyTrackerDB for saved data

### DIFF
--- a/AltCurrencyTracker.lua
+++ b/AltCurrencyTracker.lua
@@ -61,8 +61,8 @@ f:RegisterEvent("PLAYER_ENTERING_WORLD")
 
 f:SetScript("OnEvent", function(self, event, arg1)
     if event == "ADDON_LOADED" and arg1 == addonName then
-        MyCurrenciesDB = MyCurrenciesDB or {}
-        db = MyCurrenciesDB
+        AltCurrencyTrackerDB = AltCurrencyTrackerDB or {}
+        db = AltCurrencyTrackerDB
     elseif event == "PLAYER_ENTERING_WORLD" or event == "CURRENCY_DISPLAY_UPDATE" then
         UpdateCurrencies()
     end

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Simply hover over a currency in your currency panel. The tooltip will list the a
 No slash commands or additional configuration are required.
 
 ## Saved Variables
-The addon stores its data in the `MyCurrenciesDB` saved variable. If you wish to reset the stored data, you can delete this entry from your `WTF` folder while the game is closed.
+The addon stores its data in the `AltCurrencyTrackerDB` saved variable. If you wish to reset the stored data, you can delete this entry from your `WTF` folder while the game is closed.
 
 ## License
 This project is released under the MIT License.


### PR DESCRIPTION
## Summary
- replace legacy `MyCurrenciesDB` with `AltCurrencyTrackerDB`
- clarify README saved variable reference

## Testing
- `luac -p AltCurrencyTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_6895aed0b19c833381b9da4a5f18e333