### PR TITLE
Add CurseForge release workflow

### DIFF
--- a/.github/workflows/curseforge.yml
+++ b/.github/workflows/curseforge.yml
@@ -1,0 +1,18 @@
+name: CurseForge Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Package and upload
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -p 1318926
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/AltCurrencyTracker.toc
+++ b/AltCurrencyTracker.toc
@@ -3,5 +3,6 @@
 ## Author: Yaya
 ## Interface: 100107
 ## SavedVariables: AltCurrencyTrackerDB
+## X-Curse-Project-ID: 1318926
 
 AltCurrencyTracker.lua

--- a/AltCurrencyTracker.toc
+++ b/AltCurrencyTracker.toc
@@ -1,7 +1,7 @@
 ## Title: AltCurrencyTracker
 ## Version: 1.0
 ## Author: Yaya
-## Interface: 100107
+## Interface: 50500
 ## SavedVariables: AltCurrencyTrackerDB
 ## X-Curse-Project-ID: 1318926
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to package and upload tags to CurseForge via BigWigsMods/packager
- include CurseForge project ID in the addon's TOC and pass it to the workflow

## Testing
- `luacheck .` (14 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_6895e410bb0c83339577ace06b73db14