### PR TITLE
Add manual version bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,64 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Version part to increment
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fetch tags
+        run: git fetch --tags
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          echo "last_tag=$last_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: bump
+        run: |
+          last_tag="${{ steps.get_tag.outputs.last_tag }}"
+          release_type="${{ github.event.inputs.release_type }}"
+          IFS='.' read -r major minor patch <<<"$last_tag"
+          case "$release_type" in
+            major)
+              major=$((major+1)); minor=0; patch=0;;
+            minor)
+              minor=$((minor+1)); patch=0;;
+            *)
+              patch=$((patch+1));;
+          esac
+          new_tag="$major.$minor.$patch"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.bump.outputs.new_tag }}
+          release_name: ${{ steps.bump.outputs.new_tag }}


### PR DESCRIPTION
## Summary
- add manual GitHub Actions workflow to bump and release tags

## Testing
- `luac -p AltCurrencyTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689918810ad48333b5ce97e8ee435d40