### PR TITLE
chore: enable write permissions for version bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,5 +1,8 @@
 name: Bump Version
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push new version tags by granting write access

## Testing
- `yamllint .github/workflows/bump-version.yml`


------
https://chatgpt.com/codex/tasks/task_e_68991e60c1fc8333a160b693c654cc1c