### PR TITLE
ci: restrict tagging to default branch and move release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,10 +18,13 @@ on:
 
 jobs:
   bump:
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Fetch tags
         run: git fetch --tags
@@ -57,11 +60,3 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git tag "$NEW_TAG"
           git push origin "$NEW_TAG"
-
-      - name: Create GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.bump.outputs.new_tag }}
-          release_name: ${{ steps.bump.outputs.new_tag }}

--- a/.github/workflows/curseforge.yml
+++ b/.github/workflows/curseforge.yml
@@ -1,5 +1,8 @@
 name: CurseForge Release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:
@@ -16,3 +19,12 @@ jobs:
           args: -p 1318926
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          files: .release/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- restrict version bump workflow to master/main and remove GitHub release step
- add GitHub release to CurseForge workflow using packaged zip

## Testing
- `yamllint .github/workflows/bump-version.yml .github/workflows/curseforge.yml`
- `luac -p AltCurrencyTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689921bc89bc8333b907afa537e69bbe