### PR TITLE
feat: add localization for multiple languages

### DIFF
--- a/AltCurrencyTracker.lua
+++ b/AltCurrencyTracker.lua
@@ -1,6 +1,23 @@
 local addonName = ...
 local db
 
+local locale = GetLocale()
+local L = {
+    enUS = "Other characters:",
+    enGB = "Other characters:",
+    frFR = "Autres personnages :",
+    deDE = "Andere Charaktere:",
+    esES = "Otros personajes:",
+    esMX = "Otros personajes:",
+    itIT = "Altri personaggi:",
+    ptBR = "Outros personagens:",
+    ruRU = "Другие персонажи:",
+    koKR = "다른 캐릭터:",
+    zhCN = "其他角色：",
+    zhTW = "其他角色：",
+}
+local OTHER_CHARS_TEXT = L[locale] or L.enUS
+
 local function GetCharKey()
     local name, realm = UnitFullName("player")
     if not name or not realm then return nil end
@@ -35,7 +52,7 @@ local function AddCharCurrencyLinesToTooltip(GameTooltip, id)
 
     if #sorted > 0 then
         GameTooltip:AddLine(" ")
-        GameTooltip:AddLine("|cffffcc00Other characters:|r")
+        GameTooltip:AddLine("|cffffcc00" .. OTHER_CHARS_TEXT .. "|r")
         for _, char in ipairs(sorted) do
             GameTooltip:AddDoubleLine(char.name, char.amount, 1, 1, 1, 1, 1, 1)
         end

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Automatically updates on login or when your currency totals change
 - No setup or configuration needed
 - Low memory usage with a single account-wide saved variable
+- Includes localization for English, French, German, Spanish (EU & Latin America), Italian, Portuguese (Brazil), Russian, Korean, and Chinese (Simplified & Traditional)
 
 ---
 


### PR DESCRIPTION
## Summary
- add translation table covering 12 locales
- display tooltip with localized "Other characters" text
- document supported languages in README

## Testing
- `luac -p AltCurrencyTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899ae5e540c83339e01698a1b5b4469